### PR TITLE
fix: Use RPC url for tx broadcasting

### DIFF
--- a/charts/rollkit-based-network/templates/Application-Relayminer.yaml
+++ b/charts/rollkit-based-network/templates/Application-Relayminer.yaml
@@ -39,7 +39,7 @@ spec:
           pocket_node:
             query_node_rpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-sequencer:36657
             query_node_grpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-sequencer:36658
-            tx_node_grpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-sequencer:36658
+            tx_node_rpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-sequencer:36657
 
           proxies:
             - proxy_name: http-proxy


### PR DESCRIPTION
Since transaction broadcasting needs to go through Tendermint's RPC instead of gRPC URL, the config entry is renamed to tx_node_rpc_url and the port changed to the adequate value.