### PR TITLE
[Config] Add ollama service to `Application-Relayminer.yaml`

### DIFF
--- a/charts/full-network/templates/Application-Relayminer.yaml
+++ b/charts/full-network/templates/Application-Relayminer.yaml
@@ -40,12 +40,18 @@ spec:
             query_node_grpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-validator-poktrolld:36658
             tx_node_rpc_url: tcp://{{ .Values.network.type }}-{{ .Values.network.name }}-validator-poktrolld:36657
           suppliers:
+            - service_id: ollama
+              listen_url: http://0.0.0.0:8545
+              service_config:
+                backend_url: http://ollama:11434/
+                publicly_exposed_endpoints:
+                  - relayminer1 # schema and port intentionally omitted 
             - service_id: anvil
+              listen_url: http://0.0.0.0:8545
               service_config:
                 backend_url: http://anvil:8547/
                 publicly_exposed_endpoints:
-                - relayminer1
-              listen_url: http://0.0.0.0:8545
+                  - relayminer1 # schema and port intentionally omitted 
 
   syncPolicy:
     automated:


### PR DESCRIPTION
- E2E tests were failing on DevNet as seen [here](https://github.com/pokt-network/poktroll/actions/runs/8929114018/job/24529512528?pr=508)
- @okdas triaged the issue as seen in the screenshot below
- The change in this PR is the solution but uncovered that: the tooling ENFORCES RelayMiners to have an actor staked for it to start operating. The expected behaviour i:
	- RelayMiner checks if supplier is staked.
		- If it is: operate normally.
		- If it is not: throw an error, but allow deployment to continue.
- The following command can be used to verify the configs of an actor on some DevNet:
	```bash
	kubectl get cm --namespace=devnet-issue-508 devnet-issue-508-relayminer -o yaml
	```
- Se [infra notion doc](https://www.notion.so/buildwithgrove/Infrastructure-Setup-79b1431b70374e24b10cd9da556c7645?pvs=4) for instructions on how to update ArgoCD